### PR TITLE
Updated to crosstool-ng 22 and better compilation for raspberry pi 2

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,9 +4,9 @@ This document describes how to build picam. The whole process takes about 2-3 ho
 
 ## Binary releases are also available
 
-For those who don't want to build picam yourself, standalone binary is available at https://github.com/iizukanao/picam/releases/latest
+For those who don't want to build picam themselves, the standalone binary is available at https://github.com/iizukanao/picam/releases/latest
 
-Also, picam preinstalled Raspbian SD card image is available at <http://s.kyu-mu.net/raspbian-picam/>. Write it to an SD card larger than 4.5GB, boot it, then run `raspi-config` to expand the filesystem.
+Also, a SD card image preinstalled with picam on Raspbian is available at <http://s.kyu-mu.net/raspbian-picam/>. Write the image to a SD card larger than 4.5GB, boot it, then run `raspi-config` to expand the filesystem.
 
 To build picam yourself, continue reading.
 
@@ -26,7 +26,7 @@ We need to install some packages used to build crosstool-ng
 
 ## Install crosstool-ng
 
-First we need to install crosstool-ng on a powerful Linux machine (not Raspberry Pi) to be able to cross-compile ffmpeg.
+First we need to install crosstool-ng on a powerful Linux machine (not the Raspberry Pi) to be able to cross-compile ffmpeg.
 
     $ mkdir ~/pi
     $ cd ~/pi
@@ -42,7 +42,7 @@ First we need to install crosstool-ng on a powerful Linux machine (not Raspberry
     $ cd ctng
     $ ct-ng menuconfig
 
-Then a configuration screen appears. The followings are for crosstool-ng 1.22.0, and it may not be applicable to later versions.
+Then we need to configure the cross compiler for our Raspberry Pi version. The following configurations are for crosstool-ng 1.22.0, and they may not be applicable to later versions.
 
 ### For Raspberry Pi generation 1 (A, B, A+, B+, zero)
 
@@ -81,6 +81,7 @@ Then a configuration screen appears. The followings are for crosstool-ng 1.22.0,
 - Paths and misc options
     - Check "Try features marked as EXPERIMENTAL"
     - Set "Prefix directory" to "/opt/cross/x-tools/${CT_TARGET}"
+    - (OPTIONAL) Set "Number of parallel jobs" to amount of cores your processor has
 - Target options
     - Set "Target Architecture" to "arm"
     - Set "Endianness" to "Little endian"
@@ -245,7 +246,7 @@ Then, put those files into /usr/local/ so that you have /usr/local/bin/ffmpeg.
     bin  include  lib  share
     $ sudo rsync -rav ./ /usr/local/
 
-We have done with the powerful machine which we used for cross compiling.
+We are done with the powerful machine which we used for cross compiling.
 
 If you don't have /etc/ld.so.conf.d/libc.conf on Raspberry Pi, create that file with the following contents. On Raspbian, /etc/ld.so.conf.d/libc.conf is installed by default.
 
@@ -267,7 +268,7 @@ From now on, all steps are performed on Raspberry Pi.
     $ cd /opt/vc/src/hello_pi/libs/ilclient
     $ make
 
-If you do not have /opt/vc/src/ directory, download the firmware from https://github.com/raspberrypi/firmware and put all the contents under /opt/vc/src/. On Raspbian, /opt/vc/src/ is installed by default.
+If you do not have the /opt/vc/src/ directory, download the firmware from https://github.com/raspberrypi/firmware and put all the contents under /opt/vc/src/. On Raspbian, /opt/vc/src/ is installed by default.
 
 
 ## Install dependencies

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -10,6 +10,19 @@ Also, picam preinstalled Raspbian SD card image is available at <http://s.kyu-mu
 
 To build picam yourself, continue reading.
 
+## Prerequisites
+
+We need to install some packages used to build crosstool-ng
+
+### On Debian based systems
+
+    $ apt-get install flex bison automake gperf libtool patch texinfo ncurses-dev help2man
+
+### On Fedora based systems
+
+    $ yum install flex bison automake gperf libtool texinfo patch gcc gcc-c++ gmp-devel help2man
+    $ yum install ncurses-devel ncurses glibc-devel glibc-static libstdc++-static
+
 
 ## Install crosstool-ng
 
@@ -17,9 +30,9 @@ First we need to install crosstool-ng on a powerful Linux machine (not Raspberry
 
     $ mkdir ~/pi
     $ cd ~/pi
-    $ wget http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.21.0.tar.xz
-    $ tar xvf crosstool-ng-1.21.0.tar.xz
-    $ cd crosstool-ng-1.21.0
+    $ wget http://crosstool-ng.org/download/crosstool-ng/crosstool-ng-1.22.0.tar.xz
+    $ tar xvf crosstool-ng-1.22.0.tar.xz
+    $ cd crosstool-ng
     $ ./configure --prefix=/opt/cross
     $ make
     $ sudo make install
@@ -29,18 +42,19 @@ First we need to install crosstool-ng on a powerful Linux machine (not Raspberry
     $ cd ctng
     $ ct-ng menuconfig
 
-Then a configuration screen appears. The followings are for crosstool-ng 1.21.0, and it may not be applicable to later versions.
+Then a configuration screen appears. The followings are for crosstool-ng 1.22.0, and it may not be applicable to later versions.
+
+### For Raspberry Pi generation 1 (A, B, A+, B+, zero)
 
 - Paths and misc options
     - Check "Try features marked as EXPERIMENTAL"
     - Set "Prefix directory" to "/opt/cross/x-tools/${CT_TARGET}"
+    - (OPTIONAL) Set "Number of parallel jobs" to amount of cores your processor has
 - Target options
     - Set "Target Architecture" to "arm"
     - Set "Endianness" to "Little endian"
     - Set "Bitness" to "32-bit"
-    - Set "Architecture level" to "armv6zk"
     - Set "Emit assembly for CPU" to "arm1176jzf-s"
-    - Set "Tune for CPU" to "arm1176jzf-s"
     - Set "Use specific FPU" to "vfp"
     - Set "Floating point" to "hardware (FPU)"
     - Set "Default instruction set mode" to "arm"
@@ -51,18 +65,47 @@ Then a configuration screen appears. The followings are for crosstool-ng 1.21.0,
     - Set "Target OS" to "linux"
 - Binary utilities
     - Set "Binary format" to "ELF"
-    - Set "binutils version" to "2.22"
+    - Set "binutils version" to "2.25.1"
 - C-library
     - Set "C library" to "glibc"
-    - Set "glibc version" to "2.19"
+    - Set "glibc version" to "2.22"
 - C compiler
     - Check "Show Linaro versions"
-    - Set "gcc version" to "linaro-4.9-2015.03"
-    - Check "C++" under "Additional supported languages"
+    - Set "gcc version" to "linaro-4.9-2015.06"
     - Set "gcc extra config" to "--with-float=hard"
     - Check "Link libstdc++ statically into the gcc binary"
-- Companion libraries
-    - Set "ISL version" to "0.12.2"
+    - Check "C++" under "Additional supported languages"
+
+### For Raspberry Pi generation 2
+
+- Paths and misc options
+    - Check "Try features marked as EXPERIMENTAL"
+    - Set "Prefix directory" to "/opt/cross/x-tools/${CT_TARGET}"
+- Target options
+    - Set "Target Architecture" to "arm"
+    - Set "Endianness" to "Little endian"
+    - Set "Bitness" to "32-bit"
+    - Set "Emit assembly for CPU" to "cortex-a7"
+    - Set "Use specific FPU" to "neon-vfpv4"
+    - Set "Floating point" to "hardware (FPU)"
+    - Set "Default instruction set mode" to "arm"
+    - Check "Use EABI"
+- Toolchain options
+    - Set "Tuple's vendor string" to "rpi"
+- Operating System
+    - Set "Target OS" to "linux"
+- Binary utilities
+    - Set "Binary format" to "ELF"
+    - Set "binutils version" to "2.25.1"
+- C-library
+    - Set "C library" to "glibc"
+    - Set "glibc version" to "2.22"
+- C compiler
+    - Check "Show Linaro versions"
+    - Set "gcc version" to "linaro-4.9-2015.06"
+    - Set "gcc extra config" to "--with-float=hard"
+    - Check "Link libstdc++ statically into the gcc binary"
+    - Check "C++" under "Additional supported languages"
 
 Save the configuration and build.
 
@@ -181,6 +224,12 @@ If all goes well, build ffmpeg.
     $ make
     $ make install
 
+If you are running on a system with multiple cores you can invoke make with the -j option. You get the number of cores with the first command.
+
+    $ cat /proc/cpuinfo | grep processor | wc -l
+    $ make -j <num cores>
+    $ make install
+
 
 ## Transfer the files to Raspberry Pi
 
@@ -233,6 +282,7 @@ Install **libfontconfig1-dev** and **libharfbuzz-dev** via `apt-get`.
     $ cd (to anywhere you like)
     $ git clone https://github.com/iizukanao/picam.git
     $ cd picam
+    $ chmod +x whichpi
     $ make
 
 If you want to save some disk space, strip the binary.

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,19 @@
 CC=cc
-CFLAGS=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -pipe -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/src/hello_pi/libs/ilclient `freetype-config --cflags` `pkg-config --cflags harfbuzz fontconfig` -I/usr/include/fontconfig -g -Wno-deprecated-declarations -O3 -pipe -march=armv6zk -mfpu=vfp -mfloat-abi=hard
 LDFLAGS=-g -Wl,--whole-archive -lilclient -L/opt/vc/lib/ -L/usr/local/lib -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -L/opt/vc/src/hello_pi/libs/ilclient -Wl,--no-whole-archive -rdynamic -lavformat -lavcodec -ldl -lasound -lavutil -lm -lfdk-aac -lcrypto -lswresample -lz `freetype-config --libs` `pkg-config --libs harfbuzz fontconfig` -pipe
+CFLAGS=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/src/hello_pi/libs/ilclient `freetype-config --cflags` `pkg-config --cflags harfbuzz fontconfig` -I/usr/include/fontconfig -g -Wno-deprecated-declarations -O3
 DEP_LIBS=/opt/vc/src/hello_pi/libs/ilclient/libilclient.a
 SOURCES=stream.c hooks.c mpegts.c httplivestreaming.c state.c log.c text.c timestamp.c subtitle.c
 HEADERS=hooks.h mpegts.h httplivestreaming.h state.h log.h text.h timestamp.h subtitle.h
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=picam
+RASPBERRYPI = $(shell ./whichpi)
+
+# detect if we are compiling for RPi 1 or RPi 2 (or 3)
+ifeq ($(RASPBERRYPI),Pi)
+  CFLAGS += -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
+else
+	CFLAGS += -mfpu=neon-vfpv4 -mfloat-abi=hard -march=armv7-a -mtune=cortex-a7
+endif
 
 all: $(SOURCES) $(EXECUTABLE)
 

--- a/whichpi
+++ b/whichpi
@@ -1,0 +1,5 @@
+#!/bin/bash
+grep -q BCM2708 /proc/cpuinfo
+if [ $? = 0 ]; then
+  echo Pi1
+fi


### PR DESCRIPTION
Since the linaro cross compiler supports cortex-a7-NEON there should be a speed up for the x264 library on the raspberry pi 2 if you set the right compiler options. I updated the install instructions for the raspberry pi 2 and changed the makefile to use different compilation flags for the raspberry pi 1 and raspberry pi 2.

I haven't been able to cross compile for raspberry pi 3 yet, but it may be worth looking into that. Also I haven't fully tested this on a raspberry pi 1, but in theory it should work. The quick workaround to resolve the compiler flags isn't perfect, but it was the easiest way. Probably there is a better solution with autotools.

Also, there is a warning from mpegts complaining that using AVStream.codec to pass codec parameters to muxers is deprecated:
[mpegts @ 0x1c46ba0] Using AVStream.codec to pass codec parameters to muxers is deprecated, use AVStream.codecpar instead.