### PR TITLE
Display texts in preview using dispmanx overlay 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ RASPBERRYPI=$(shell sh ./whichpi)
 GCCVERSION=$(shell gcc --version | grep ^gcc | sed "s/.* //g")
 
 # detect if we are compiling for RPi 1 or RPi 2 (or 3)
-ifeq ($(RASPBERRYPI),Pi)
+ifeq ($(RASPBERRYPI),Pi1)
 	CFLAGS += -mfpu=vfp -mfloat-abi=hard -march=armv6zk -mtune=arm1176jzf-s
 else
 ifneq (,$(findstring 4.6.,$(GCCVERSION)))  # gcc version 4.6.x

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ CC=cc
 CFLAGS=-DSTANDALONE -D__STDC_CONSTANT_MACROS -D__STDC_LIMIT_MACROS -DTARGET_POSIX -D_LINUX -fPIC -DPIC -D_REENTRANT -D_LARGEFILE64_SOURCE -D_FILE_OFFSET_BITS=64 -U_FORTIFY_SOURCE -Wall -g -DHAVE_LIBOPENMAX=2 -DOMX -DOMX_SKIP64BIT -ftree-vectorize -DUSE_EXTERNAL_OMX -DHAVE_LIBBCM_HOST -DUSE_EXTERNAL_LIBBCM_HOST -DUSE_VCHIQ_ARM -Wno-psabi -I/opt/vc/include/ -I/opt/vc/include/interface/vcos/pthreads -I/opt/vc/include/interface/vmcs_host/linux -I/opt/vc/src/hello_pi/libs/ilclient `freetype-config --cflags` `pkg-config --cflags harfbuzz fontconfig libavformat libavcodec` -I/usr/include/fontconfig -g -Wno-deprecated-declarations -O3
 LDFLAGS=-g -Wl,--whole-archive -lilclient -L/opt/vc/lib/ -L/usr/local/lib -lGLESv2 -lEGL -lopenmaxil -lbcm_host -lvcos -lvchiq_arm -lpthread -lrt -L/opt/vc/src/hello_pi/libs/ilclient -Wl,--no-whole-archive -rdynamic -lm -lcrypto -lasound `freetype-config --libs` `pkg-config --libs harfbuzz fontconfig libavformat libavcodec`
 DEP_LIBS=/opt/vc/src/hello_pi/libs/ilclient/libilclient.a
-SOURCES=stream.c hooks.c mpegts.c httplivestreaming.c state.c log.c text.c timestamp.c subtitle.c
-HEADERS=hooks.h mpegts.h httplivestreaming.h state.h log.h text.h timestamp.h subtitle.h
+SOURCES=stream.c hooks.c mpegts.c httplivestreaming.c state.c log.c text.c timestamp.c subtitle.c dispmanx.c
+HEADERS=hooks.h mpegts.h httplivestreaming.h state.h log.h text.h timestamp.h subtitle.h dispmanx.h
 OBJECTS=$(SOURCES:.c=.o)
 EXECUTABLE=picam
 RASPBERRYPI=$(shell sh ./whichpi)

--- a/README.md
+++ b/README.md
@@ -385,6 +385,8 @@ Each line of hooks/subtitle must be in the format of `key=value`. Lines starting
 | color | Text color in hex color code. Rendered in grayscale. | ffffff |
 | stroke_color | Text stroke (outline) color in hex color code. Rendered in grayscale. | 000000 |
 | stroke_width | Text stroke (outline) border radius in points | 1.0 |
+| in_preview | Visibility of the text in the preview | 1 |
+| in_video | Visibility of the text in the encoded video | 1 |
 
 NOTE: On the first generation models of Raspberry Pi (before Pi 2), subtitles cause CPU usage high and the video frame rate may drop below 30 fps.
 

--- a/dispmanx.c
+++ b/dispmanx.c
@@ -1,0 +1,218 @@
+#include "dispmanx.h"
+#include "log.h"
+#include "text.h"
+
+#include <stdint.h>
+#include <assert.h>
+
+#include <bcm_host.h>
+
+// for debugging: write TEST DATA
+//#define DEBUG_FILL_TEXT_OVERLAY
+
+
+static DISPMANX_DISPLAY_HANDLE_T   g_display;
+static DISPMANX_MODEINFO_T         g_modeInfo;
+static DISPMANX_ELEMENT_HANDLE_T   g_bgElement;
+static DISPMANX_RESOURCE_HANDLE_T  g_bgResource;
+
+static DISPMANX_ELEMENT_HANDLE_T   g_textElement;
+static DISPMANX_RESOURCE_HANDLE_T  g_frontResource;
+static DISPMANX_RESOURCE_HANDLE_T  g_backResource;
+
+static uint8_t* g_canvas;
+static uint32_t g_canvas_size;
+static uint32_t g_canvas_height;
+static uint32_t g_canvas_width;
+
+#define DISP_CANVAS_BYTES_PER_PIXEL 4
+
+#ifdef DEBUG_FILL_TEXT_OVERLAY
+// just for testing: works only with ARGB images
+static void fill_rect(VC_IMAGE_TYPE_T type, void *canvas, int width, int height, int x, int y, int w, int h, int val)
+{
+  int         row;
+  int         col;
+
+  int pitch = width * DISP_CANVAS_BYTES_PER_PIXEL;
+  uint32_t *line = (uint32_t*)((uint8_t *)(canvas) + ((y * width) + x) * DISP_CANVAS_BYTES_PER_PIXEL);
+
+  for (row = 0; row < h; ++row) {
+    for (col = 0; col < w; ++col) {
+        line[col] = val;
+    }
+    line = (uint32_t*)((uint8_t *)line + pitch);
+  }
+}
+#endif
+
+static void dispmanx_create_background(uint32_t argb)
+{
+  VC_RECT_T dst_rect, src_rect;
+  DISPMANX_UPDATE_HANDLE_T update;
+  uint32_t vc_image_ptr;
+  int ret;
+
+  // if alpha is fully transparent then background has no effect
+  if (!(argb & 0xff000000)) {
+    log_debug("dispmanx_create_background: fully transparent not creating overlay\n");
+    return;
+  }
+
+  // background: we create a 1x1 black pixel image that is added to display just behind video
+  g_bgResource = vc_dispmanx_resource_create(VC_IMAGE_ARGB8888, 1 /*width*/, 1 /*height*/, &vc_image_ptr);
+  assert(g_bgResource);
+
+  vc_dispmanx_rect_set( &dst_rect, 0, 0, 1, 1);
+
+  ret = vc_dispmanx_resource_write_data(g_bgResource, VC_IMAGE_ARGB8888, sizeof(argb), &argb, &dst_rect);
+  assert(ret == 0);
+
+  vc_dispmanx_rect_set(&src_rect, 0, 0, 1<<16, 1<<16);
+  vc_dispmanx_rect_set(&dst_rect, 0, 0, 0, 0);
+
+  update = vc_dispmanx_update_start(0);
+  assert(update);
+
+  g_bgElement = vc_dispmanx_element_add(update, g_display, DISP_LAYER_BACKGROUD, &dst_rect, g_bgResource, &src_rect,
+                                      DISPMANX_PROTECTION_NONE, NULL, NULL, DISPMANX_STEREOSCOPIC_MONO);
+  assert(g_bgElement);
+
+  ret = vc_dispmanx_update_submit_sync(update);
+  assert(ret == 0);
+}
+
+static void dispmanx_create_text_overlay(void)
+{
+  VC_RECT_T dst_rect, src_rect;
+  DISPMANX_UPDATE_HANDLE_T update;
+  uint32_t vc_image_ptr;
+  int ret;
+
+  int width = g_modeInfo.width;
+  int height = g_modeInfo.height;
+
+#if 0
+  VC_DISPMANX_ALPHA_T alpha = { DISPMANX_FLAGS_ALPHA_FROM_SOURCE | DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS,
+                           255, /*alpha 0->255*/
+                           0 };
+#endif
+
+  // we will be using double buffering - we're creating two resources with the size of the screen
+  g_frontResource = vc_dispmanx_resource_create(VC_IMAGE_ARGB8888, width, height, &vc_image_ptr);
+  assert(g_frontResource);
+  g_backResource = vc_dispmanx_resource_create(VC_IMAGE_ARGB8888, width, height, &vc_image_ptr);
+  assert(g_backResource);
+
+  g_canvas_height = ALIGN_UP(height, 16);
+  g_canvas_width  = ALIGN_UP(width, 32);
+  int pitch = g_canvas_width * DISP_CANVAS_BYTES_PER_PIXEL;
+  g_canvas_size = pitch * g_canvas_height;
+  g_canvas = calloc(1, g_canvas_size);
+  assert(g_canvas);
+
+#ifdef DEBUG_FILL_TEXT_OVERLAY
+  // for debugging: write TEST DATA
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  100, 100, 200, 200,     0xFFFF0000);
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  100, 600, 500, 200,     0xFFFF0000);
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  150, 150, 200, 200,     0xFF00FF00);
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  500, 500, 200, 200,     0x8800FF00);
+
+  vc_dispmanx_rect_set(&dst_rect, 0, 0, width, height);
+  ret = vc_dispmanx_resource_write_data(g_frontResource, VC_IMAGE_ARGB8888, pitch, g_canvas, &dst_rect);
+  assert(ret == 0);
+#endif
+
+  vc_dispmanx_rect_set(&src_rect, 0, 0, width << 16, height << 16);
+  vc_dispmanx_rect_set(&dst_rect, 0, 0, width, height);
+
+  update = vc_dispmanx_update_start(0);
+  assert(update);
+
+  g_textElement = vc_dispmanx_element_add(update, g_display, DISP_LAYER_TEXT, &dst_rect, g_frontResource, &src_rect,
+                                      DISPMANX_PROTECTION_NONE, 0 /*&alpha*/, NULL, DISPMANX_STEREOSCOPIC_MONO);
+  assert(g_textElement);
+
+  ret = vc_dispmanx_update_submit_sync(update);
+  assert(ret == 0);
+  log_debug("dispmanx: text overlay created!\n");
+}
+
+void dispmanx_init(uint32_t bg_color)
+{
+  int ret;
+  log_debug("dispmanx: init\n");
+  g_display = vc_dispmanx_display_open(DISP_DISPLAY_DEFAULT);
+  assert(g_display);
+
+  ret = vc_dispmanx_display_get_info(g_display, &g_modeInfo);
+  assert(ret == 0);
+  log_info("dispmanx: display %d: %d x %d\n", DISP_DISPLAY_DEFAULT, g_modeInfo.width, g_modeInfo.height);
+
+  dispmanx_create_background(bg_color);
+  dispmanx_create_text_overlay();
+}
+
+#define ELEMENT_REMOVE_IF_EXISTS(_elem) do { if (_elem) { ret = vc_dispmanx_element_remove(update, _elem); assert(ret == 0); } } while(0)
+#define RESOURCE_DELETE_IF_EXISTS(_res) do { if (_res) { ret = vc_dispmanx_resource_delete(_res); assert(ret == 0); } } while(0)
+
+void dispmanx_destroy(void)
+{
+  DISPMANX_UPDATE_HANDLE_T update;
+  int ret;
+
+  free(g_canvas);
+
+  log_debug("dispmanx: destroy\n");
+  update = vc_dispmanx_update_start(0);
+  assert(update != 0);
+
+  ELEMENT_REMOVE_IF_EXISTS(g_bgElement);
+  ELEMENT_REMOVE_IF_EXISTS(g_textElement);
+
+  ret = vc_dispmanx_update_submit_sync(update);
+  assert(ret == 0);
+
+  RESOURCE_DELETE_IF_EXISTS(g_bgResource);
+  RESOURCE_DELETE_IF_EXISTS(g_frontResource);
+  RESOURCE_DELETE_IF_EXISTS(g_backResource);
+
+  ret = vc_dispmanx_display_close(g_display);
+  assert(ret == 0);
+}
+
+void dispmanx_update_text_overlay(void)
+{
+  VC_RECT_T dst_rect;
+  int ret;
+  //clock_t start_time = clock();
+  
+
+  // reset overlay to fully-transparent
+  memset(g_canvas, 0, g_canvas_size);
+
+  // render texts
+  text_draw_all(g_canvas, g_canvas_width, g_canvas_height, 1); // is_argb = 1
+
+  // write data to back resource
+  vc_dispmanx_rect_set(&dst_rect, 0, 0, g_modeInfo.width, g_modeInfo.height);
+  int pitch = g_canvas_width * DISP_CANVAS_BYTES_PER_PIXEL;
+  ret = vc_dispmanx_resource_write_data(g_backResource, VC_IMAGE_ARGB8888, pitch, g_canvas, &dst_rect);
+  assert(ret == 0);
+
+  // change the source of text overlay
+  DISPMANX_UPDATE_HANDLE_T update = vc_dispmanx_update_start(0);
+  assert(update != 0);
+  
+  ret = vc_dispmanx_element_change_source(update, g_textElement, g_backResource);
+
+  assert(ret == 0);
+  ret = vc_dispmanx_update_submit(update, NULL, NULL);
+  assert(ret == 0);
+
+  // back <-> front
+  DISPMANX_RESOURCE_HANDLE_T tmpResource = g_frontResource;
+  g_frontResource = g_backResource;
+  g_backResource = tmpResource;
+  //log_debug("dispmanx: update took %d ms\n", (clock() - start_time) * 1000 / CLOCKS_PER_SEC);
+}

--- a/dispmanx.c
+++ b/dispmanx.c
@@ -25,6 +25,9 @@ static uint32_t g_canvas_size;
 static uint32_t g_canvas_height;
 static uint32_t g_canvas_width;
 
+static uint32_t g_video_width;
+static uint32_t g_video_height;
+
 #define DISP_CANVAS_BYTES_PER_PIXEL 4
 
 #ifdef DEBUG_FILL_TEXT_OVERLAY
@@ -37,8 +40,8 @@ static void fill_rect(VC_IMAGE_TYPE_T type, void *canvas, int width, int height,
   int pitch = width * DISP_CANVAS_BYTES_PER_PIXEL;
   uint32_t *line = (uint32_t*)((uint8_t *)(canvas) + ((y * width) + x) * DISP_CANVAS_BYTES_PER_PIXEL);
 
-  for (row = 0; row < h; ++row) {
-    for (col = 0; col < w; ++col) {
+  for (row = 0; (row < h) && (y + row < height); ++row) {
+    for (col = 0; (col < w) && (x + col < width); ++col) {
         line[col] = val;
     }
     line = (uint32_t*)((uint8_t *)line + pitch);
@@ -89,8 +92,10 @@ static void dispmanx_create_text_overlay(void)
   uint32_t vc_image_ptr;
   int ret;
 
-  int width = g_modeInfo.width;
-  int height = g_modeInfo.height;
+  int width  = ALIGN_UP(g_video_width,  32);
+  int height = ALIGN_UP(g_video_height, 16);
+  int x = (g_modeInfo.width - width) / 2;
+  int y = (g_modeInfo.height - height) / 2;
 
 #if 0
   VC_DISPMANX_ALPHA_T alpha = { DISPMANX_FLAGS_ALPHA_FROM_SOURCE | DISPMANX_FLAGS_ALPHA_FIXED_ALL_PIXELS,
@@ -104,8 +109,8 @@ static void dispmanx_create_text_overlay(void)
   g_backResource = vc_dispmanx_resource_create(VC_IMAGE_ARGB8888, width, height, &vc_image_ptr);
   assert(g_backResource);
 
-  g_canvas_height = ALIGN_UP(height, 16);
-  g_canvas_width  = ALIGN_UP(width, 32);
+  g_canvas_height = height;
+  g_canvas_width  = width;
   int pitch = g_canvas_width * DISP_CANVAS_BYTES_PER_PIXEL;
   g_canvas_size = pitch * g_canvas_height;
   g_canvas = calloc(1, g_canvas_size);
@@ -113,8 +118,9 @@ static void dispmanx_create_text_overlay(void)
 
 #ifdef DEBUG_FILL_TEXT_OVERLAY
   // for debugging: write TEST DATA
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  0, 0, 50, 50,     0xFFFFFFFF);
   fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  100, 100, 200, 200,     0xFFFF0000);
-  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  100, 600, 500, 200,     0xFFFF0000);
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  1100, 600, 500, 200,     0xFF0000FF);
   fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  150, 150, 200, 200,     0xFF00FF00);
   fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  500, 500, 200, 200,     0x8800FF00);
 
@@ -124,7 +130,7 @@ static void dispmanx_create_text_overlay(void)
 #endif
 
   vc_dispmanx_rect_set(&src_rect, 0, 0, width << 16, height << 16);
-  vc_dispmanx_rect_set(&dst_rect, 0, 0, width, height);
+  vc_dispmanx_rect_set(&dst_rect, x, y, width, height);
 
   update = vc_dispmanx_update_start(0);
   assert(update);
@@ -138,16 +144,19 @@ static void dispmanx_create_text_overlay(void)
   log_debug("dispmanx: text overlay created!\n");
 }
 
-void dispmanx_init(uint32_t bg_color)
+void dispmanx_init(uint32_t bg_color, uint32_t video_width, uint32_t video_height)
 {
   int ret;
   log_debug("dispmanx: init\n");
   g_display = vc_dispmanx_display_open(DISP_DISPLAY_DEFAULT);
   assert(g_display);
 
+  g_video_width = video_width;
+  g_video_height = video_height;
   ret = vc_dispmanx_display_get_info(g_display, &g_modeInfo);
   assert(ret == 0);
-  log_info("dispmanx: display %d: %d x %d\n", DISP_DISPLAY_DEFAULT, g_modeInfo.width, g_modeInfo.height);
+  log_info("dispmanx: display %d: %d x %d (video: %d x %d) \n", DISP_DISPLAY_DEFAULT,
+      g_modeInfo.width, g_modeInfo.height, g_video_width, g_video_height);
 
   dispmanx_create_background(bg_color);
   dispmanx_create_text_overlay();
@@ -195,7 +204,7 @@ void dispmanx_update_text_overlay(void)
   text_draw_all(g_canvas, g_canvas_width, g_canvas_height, 0); // is_video = 0
 
   // write data to back resource
-  vc_dispmanx_rect_set(&dst_rect, 0, 0, g_modeInfo.width, g_modeInfo.height);
+  vc_dispmanx_rect_set(&dst_rect, 0, 0, g_canvas_width, g_canvas_height);
   int pitch = g_canvas_width * DISP_CANVAS_BYTES_PER_PIXEL;
   ret = vc_dispmanx_resource_write_data(g_backResource, VC_IMAGE_ARGB8888, pitch, g_canvas, &dst_rect);
   assert(ret == 0);

--- a/dispmanx.c
+++ b/dispmanx.c
@@ -192,7 +192,7 @@ void dispmanx_update_text_overlay(void)
   memset(g_canvas, 0, g_canvas_size);
 
   // render texts
-  text_draw_all(g_canvas, g_canvas_width, g_canvas_height, 1); // is_argb = 1
+  text_draw_all(g_canvas, g_canvas_width, g_canvas_height, 0); // is_video = 0
 
   // write data to back resource
   vc_dispmanx_rect_set(&dst_rect, 0, 0, g_modeInfo.width, g_modeInfo.height);

--- a/dispmanx.c
+++ b/dispmanx.c
@@ -7,7 +7,8 @@
 
 #include <bcm_host.h>
 
-// for debugging: write TEST DATA
+// for debugging: write TEST DATA at startup
+// and semi-transparet overlay each refresh to see all th texts overlayed
 //#define DEBUG_FILL_TEXT_OVERLAY
 
 
@@ -199,6 +200,10 @@ void dispmanx_update_text_overlay(void)
 
   // reset overlay to fully-transparent
   memset(g_canvas, 0, g_canvas_size);
+#ifdef DEBUG_FILL_TEXT_OVERLAY // really nice: see refresehed areas (layout boxes)
+  fill_rect(VC_IMAGE_ARGB8888, g_canvas, g_canvas_width, g_canvas_height,  0, 0, g_canvas_width, g_canvas_height,     0x33ff0000);
+#endif
+
 
   // render texts
   text_draw_all(g_canvas, g_canvas_width, g_canvas_height, 0); // is_video = 0

--- a/dispmanx.h
+++ b/dispmanx.h
@@ -1,0 +1,21 @@
+#ifndef PICAM_DISPMANX_H
+#define PICAM_DISPMANX_H
+
+#include <stdint.h>
+
+// dispmanx layers consts for displaying multiple accelerated overlays in preview
+#define DISP_LAYER_BACKGROUD     0xe
+#define DISP_LAYER_VIDEO_PREVIEW 0xf
+#define DISP_LAYER_TEXT          0x1f
+
+// default ARGB color for preview background (black)
+#define BLANK_BACKGROUND_DEFAULT    0xff000000
+
+// display to which we will output the preview overlays
+#define DISP_DISPLAY_DEFAULT     0
+
+void dispmanx_init(uint32_t bg_color);
+void dispmanx_destroy(void);
+void dispmanx_update_text_overlay(void);
+
+#endif

--- a/dispmanx.h
+++ b/dispmanx.h
@@ -14,7 +14,7 @@
 // display to which we will output the preview overlays
 #define DISP_DISPLAY_DEFAULT     0
 
-void dispmanx_init(uint32_t bg_color);
+void dispmanx_init(uint32_t bg_color, uint32_t video_width, uint32_t video_height);
 void dispmanx_destroy(void);
 void dispmanx_update_text_overlay(void);
 

--- a/log.h
+++ b/log.h
@@ -1,6 +1,7 @@
 #ifndef _LOG_H_
 #define _LOG_H_
 
+#include <stdio.h>
 #include <stdarg.h>
 
 enum {

--- a/stream.c
+++ b/stream.c
@@ -43,6 +43,7 @@ extern "C" {
 #include "state.h"
 #include "log.h"
 #include "text.h"
+#include "dispmanx.h"
 #include "timestamp.h"
 #include "subtitle.h"
 
@@ -90,16 +91,6 @@ extern "C" {
 #define FILL_COLOR_Y 0
 #define FILL_COLOR_U 128
 #define FILL_COLOR_V 128
-
-// default ARGB color for preview background (black)
-#define BLANK_BACKGROUND_DEFAULT    0xff000000
-
-// dispmanx layers consts for displaying multiple accelerated overlays in preview
-#define LAYER_BACKGROUD     0xe
-#define LAYER_VIDEO_PREVIEW 0xf
-
-// display to which we will output the preview overlays
-#define DISPLAY_DEFAULT     0
 
 // Whether or not to pass pBuffer from camera to video_encode directly
 #define ENABLE_PBUFFER_OPTIMIZATION_HACK 1
@@ -2956,7 +2947,11 @@ static void cam_fill_buffer_done(void *data, COMPONENT_T *comp) {
             log_debug(".");
             timestamp_update();
             subtitle_update();
-            text_draw_all(last_video_buffer, video_width_32, video_height_16);
+            int is_text_changed = text_draw_all(last_video_buffer, video_width_32, video_height_16, 0); // is_argb = 0
+            if (is_text_changed && is_preview_enabled) {
+              // the text has actually changed, redraw preview subtitle overlay
+              dispmanx_update_text_overlay();
+            }
             encode_and_send_image();
           }
         }
@@ -3135,49 +3130,6 @@ static int camera_set_white_balance(char *wb) {
   }
 
   return 0;
-}
-
-// NOTE: function based on https://github.com/popcornmix/omxplayer/blob/master/omxplayer.cpp
-static void create_blank_background(uint32_t argb)
-{
-  // if alpha is fully transparent then background has no effect
-  if (!(argb & 0xff000000))
-    return;
-  // we create a 1x1 black pixel image that is added to display just behind video
-  DISPMANX_DISPLAY_HANDLE_T   display;
-  DISPMANX_UPDATE_HANDLE_T    update;
-  DISPMANX_RESOURCE_HANDLE_T  resource;
-  DISPMANX_ELEMENT_HANDLE_T   element;
-  int             ret;
-  uint32_t vc_image_ptr;
-  VC_IMAGE_TYPE_T type = VC_IMAGE_ARGB8888;
-  int             layer = LAYER_BACKGROUD;
-
-  VC_RECT_T dst_rect, src_rect;
-
-  display = vc_dispmanx_display_open(DISPLAY_DEFAULT);
-  assert(display);
-
-  resource = vc_dispmanx_resource_create( type, 1 /*width*/, 1 /*height*/, &vc_image_ptr );
-  assert( resource );
-
-  vc_dispmanx_rect_set( &dst_rect, 0, 0, 1, 1);
-
-  ret = vc_dispmanx_resource_write_data( resource, type, sizeof(argb), &argb, &dst_rect );
-  assert(ret == 0);
-
-  vc_dispmanx_rect_set( &src_rect, 0, 0, 1<<16, 1<<16);
-  vc_dispmanx_rect_set( &dst_rect, 0, 0, 0, 0);
-
-  update = vc_dispmanx_update_start(0);
-  assert(update);
-
-  element = vc_dispmanx_element_add(update, display, layer, &dst_rect, resource, &src_rect,
-                                    DISPMANX_PROTECTION_NONE, NULL, NULL, DISPMANX_STEREOSCOPIC_MONO );
-  assert(element);
-
-  ret = vc_dispmanx_update_submit_sync( update );
-  assert( ret == 0 );
 }
 
 static int openmax_cam_open() {
@@ -3414,9 +3366,6 @@ static int openmax_cam_open() {
     }
     component_list[n_component_list++] = render_component;
 
-    // setup background overlay
-    create_blank_background(blank_background_color);
-
     // Setup display region for preview window
     memset(&display_region, 0, sizeof(OMX_CONFIG_DISPLAYREGIONTYPE));
     display_region.nSize = sizeof(OMX_CONFIG_DISPLAYREGIONTYPE);
@@ -3424,7 +3373,7 @@ static int openmax_cam_open() {
     display_region.nPortIndex = VIDEO_RENDER_INPUT_PORT;
 
     // set default display
-    display_region.num = DISPLAY_DEFAULT;
+    display_region.num = DISP_DISPLAY_DEFAULT;
 
     if (is_previewrect_enabled) { // display preview window at specified position
       display_region.set = OMX_DISPLAY_SET_DEST_RECT | OMX_DISPLAY_SET_FULLSCREEN | OMX_DISPLAY_SET_NOASPECT | OMX_DISPLAY_SET_NUM;
@@ -3449,7 +3398,7 @@ static int openmax_cam_open() {
     // Set the opacity and layer of the preview window
     display_region.set = OMX_DISPLAY_SET_ALPHA | OMX_DISPLAY_SET_LAYER;
     display_region.alpha = (OMX_U32) preview_opacity;
-    display_region.layer = LAYER_VIDEO_PREVIEW;
+    display_region.layer = DISP_LAYER_VIDEO_PREVIEW;
     error = OMX_SetParameter(ILC_GET_HANDLE(render_component),
         OMX_IndexConfigDisplayRegion, &display_region);
     if (error != OMX_ErrorNone) {
@@ -5707,6 +5656,11 @@ int main(int argc, char **argv) {
   }
   memset(component_list, 0, sizeof(component_list));
 
+  if (is_preview_enabled) {
+    // setup dispmanx preview (backgroud + subtitle overlay)
+    dispmanx_init(blank_background_color);
+  }
+
   ret = openmax_cam_open();
   if (ret != 0) {
     log_fatal("error: openmax_cam_open failed: %d\n", ret);
@@ -5879,6 +5833,9 @@ int main(int argc, char **argv) {
   }
 
   stop_openmax_capturing();
+  if (is_preview_enabled) {
+    dispmanx_destroy();
+  }
   shutdown_openmax();
   shutdown_video();
 

--- a/stream.c
+++ b/stream.c
@@ -1390,6 +1390,8 @@ void on_file_create(char *filename, char *content) {
     TEXT_ALIGN text_align = TEXT_ALIGN_CENTER;
     int horizontal_margin = 0;
     int vertical_margin = 35;
+    int in_preview = 1;
+    int in_video = 1;
 
     char filepath[256];
     snprintf(filepath, sizeof(filepath), "%s/%s", hooks_dir, filename);
@@ -1616,6 +1618,22 @@ void on_file_create(char *filename, char *content) {
               }
               search_p = comma_p + 1;
             }
+          } else if (strncmp(line, "in_preview=", key_len+1) == 0) {
+            char *end;
+            double value = strtod(delimiter_p+1, &end);
+            if (end == delimiter_p+1 || *end != '\0' || errno == ERANGE) { // parse error
+              log_error("subtitle error: invalid in_preview: %s\n", delimiter_p+1);
+              return;
+            }
+            in_preview = (value != 0);
+          } else if (strncmp(line, "in_video=", key_len+1) == 0) {
+            char *end;
+            double value = strtod(delimiter_p+1, &end);
+            if (end == delimiter_p+1 || *end != '\0' || errno == ERANGE) { // parse error
+              log_error("subtitle error: invalid in_video: %s\n", delimiter_p+1);
+              return;
+            }
+            in_video = (value != 0);
           } else {
             log_error("subtitle error: cannot parse line: %s\n", line);
           }
@@ -1672,6 +1690,7 @@ void on_file_create(char *filename, char *content) {
         subtitle_set_color(color);
         subtitle_set_stroke_color(stroke_color);
         subtitle_set_stroke_width(stroke_width);
+        subtitle_set_visibility(in_preview, in_video);
         subtitle_set_letter_spacing(letter_spacing);
         subtitle_set_line_height_multiply(line_height_multiply);
         subtitle_set_tab_scale(tab_scale);
@@ -2947,7 +2966,7 @@ static void cam_fill_buffer_done(void *data, COMPONENT_T *comp) {
             log_debug(".");
             timestamp_update();
             subtitle_update();
-            int is_text_changed = text_draw_all(last_video_buffer, video_width_32, video_height_16, 0); // is_argb = 0
+            int is_text_changed = text_draw_all(last_video_buffer, video_width_32, video_height_16, 1); // is_video = 1
             if (is_text_changed && is_preview_enabled) {
               // the text has actually changed, redraw preview subtitle overlay
               dispmanx_update_text_overlay();

--- a/stream.c
+++ b/stream.c
@@ -5677,7 +5677,7 @@ int main(int argc, char **argv) {
 
   if (is_preview_enabled) {
     // setup dispmanx preview (backgroud + subtitle overlay)
-    dispmanx_init(blank_background_color);
+    dispmanx_init(blank_background_color, video_width, video_height);
   }
 
   ret = openmax_cam_open();

--- a/subtitle.c
+++ b/subtitle.c
@@ -68,6 +68,13 @@ void subtitle_set_color(int color) {
 }
 
 /**
+ * Sets text visibility
+ */
+void subtitle_set_visibility(int in_preview, int in_video) {
+  text_set_visibility(text_id, in_preview, in_video);
+}
+
+/**
  * Sets text stroke color.
  */
 void subtitle_set_stroke_color(uint32_t color) {

--- a/subtitle.h
+++ b/subtitle.h
@@ -22,6 +22,11 @@ void subtitle_shutdown();
 void subtitle_set_color(int color);
 
 /**
+ * Sets text visibility
+ */
+void subtitle_set_visibility(int in_preview, int in_video);
+
+/**
  * Sets text stroke color.
  */
 void subtitle_set_stroke_color(uint32_t color);

--- a/text.c
+++ b/text.c
@@ -506,6 +506,7 @@ int text_destroy(int text_id) {
     return -1; // non-existent text id
   }
   TextData *textdata = textdata_list[text_id-1];
+  textdata->has_changed = 1;
   textdata->will_dispose_bitmap = 1;
   return 0;
 }
@@ -1120,6 +1121,10 @@ int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_v
       }
       has_anything_changed |= textdata->has_changed;
       textdata->has_changed = 0;
+      if (textdata->will_dispose_bitmap) {
+        text_destroy_real(textdata->id);
+        continue;
+      }
       if (textdata->is_bitmap_ready) {
         if ((is_video && !textdata->in_video)
             || (!is_video && !textdata->in_preview)) {
@@ -1189,12 +1194,9 @@ int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_v
           }
         }
       }
-      if (textdata->will_dispose_bitmap) {
-        text_destroy_real(textdata->id);
-      }
     }
   }
-  //log_debug("text_draw_all(is_canvas_argb=%d) took %d ms\n", is_canvas_argb, (clock() - start_time) * 1000 / CLOCKS_PER_SEC);
+  //log_debug("\n\ntext_draw_all(is_video=%d) took %d ms, has_changed=%d\n", is_video, (clock() - start_time) * 1000 / CLOCKS_PER_SEC, has_anything_changed);
   return has_anything_changed;
 }
 

--- a/text.c
+++ b/text.c
@@ -1,5 +1,7 @@
 #include <stdint.h>
 #include <math.h>
+#include <time.h> // clock()
+#include "log.h"
 
 // FreeType
 #include <ft2build.h>
@@ -49,6 +51,10 @@ typedef enum BlendMode {
   BLEND_MODE_LIGHTEN_ONLY = 3,
 } BlendMode;
 
+//NOTE: enable if you need to blend multiple text overlays in preview and can trade off lower FPS because of that
+// If You really need it, use multiple dispmanx layers (or EGL overlay) and let the hardware do the blending
+//#define USE_ARGB_PIXEL_BLENDING
+
 // Represents a text object
 typedef struct TextData {
   int id;
@@ -69,6 +75,7 @@ typedef struct TextData {
 
   int is_bitmap_ready;
   int will_dispose_bitmap;
+  int has_changed; // do we need to redraw the overlay
   int width;
   int height;
   int is_stroke;
@@ -210,6 +217,7 @@ int text_create(const char *font_file, long face_index, float point, int dpi) {
   textdata->id = text_id;
   textdata->bitmap = NULL;
   textdata->is_bitmap_ready = 0;
+  textdata->has_changed = 0;
   textdata->will_dispose_bitmap = 0;
   textdata->width = 0;
   textdata->height = 0;
@@ -680,7 +688,43 @@ int text_get_bounds(int text_id, const char *text, size_t text_len, text_bounds 
   return 0;
 }
 
+// NOTE: PI is little-endian so the actual color order in memory is as below
+typedef union {
+  uint32_t x;
+  struct {
+    uint8_t b;
+    uint8_t g;
+    uint8_t r;
+    uint8_t a;
+  } c;
+} color_argb_t;
+
+static color_argb_t blend_colors_argb(color_argb_t bg_color, color_argb_t fg_color, BlendMode blend_mode)
+{
+  color_argb_t out;
+
+  if (blend_mode != BLEND_MODE_NORMAL) {
+    // TODO: Implement other blending modes
+    fprintf(stderr, "blend_colors_argb: blending mode not implemented: %d\n", blend_mode);
+    blend_mode = BLEND_MODE_NORMAL;
+  }
+
+  // shortcut
+  if (bg_color.c.a == 0 || fg_color.c.a == 0xff) {
+    return fg_color;
+  }
+
+  // alpha blending two ARGB from wikipedia:
+  out.c.r = fg_color.c.r * fg_color.c.a / 255 + (bg_color.c.r * bg_color.c.a * (255 - fg_color.c.a) / (255 * 255));
+  out.c.g = fg_color.c.g * fg_color.c.a / 255 + (bg_color.c.g * bg_color.c.a * (255 - fg_color.c.a) / (255 * 255));
+  out.c.b = fg_color.c.b * fg_color.c.a / 255 + (bg_color.c.b * bg_color.c.a * (255 - fg_color.c.a) / (255 * 255));
+  out.c.a = fg_color.c.a + (bg_color.c.a * (255 - fg_color.c.a) / 255);
+
+  return out;
+}
+
 // callback function for drawing the glyphs of the text.
+// NOTE: we're creating full 32-bit bitmap
 void span_writer_callback(int y, int count, const FT_Span* spans, void *user) {
   TextData *textdata = (TextData *) user;
   int row = -y - textdata->bounds_top;
@@ -694,7 +738,7 @@ void span_writer_callback(int y, int count, const FT_Span* spans, void *user) {
   int total_length = 0;
   for (i = 0; i < count; i++) {
     uint8_t opacity = spans[i].coverage;
-    uint8_t *start = scanline + spans[i].x * BYTES_PER_PIXEL;
+    uint32_t* start = (uint32_t*)(scanline + spans[i].x * BYTES_PER_PIXEL);
 
     int x;
     for (x = 0; x < spans[i].len; x++) {
@@ -702,29 +746,17 @@ void span_writer_callback(int y, int count, const FT_Span* spans, void *user) {
         return;
       }
       if (opacity == 0) {
-        start += BYTES_PER_PIXEL;
+        ++start;
       } else {
-        uint8_t orig_opacity = *start;
-        float intensity;
-        if (opacity > 0) {
-          intensity = opacity / 255.0f;
-        } else {
-          intensity = 0.0f;
-        }
-        if (opacity > orig_opacity) {
-          *start = opacity;
-        }
-        start++;
-        if (textdata->is_stroke) { // this is pass 1 (outline)
-          *start = *start * (1 - intensity) + ((textdata->stroke_color >> 4) & 0xff) * intensity;
-          start += 3;
-          // TODO: map green and blue to UV
-        } else { // this is pass 2 (fill)
-          // red
-          *start = *start * (1 - intensity) + ((textdata->color >> 4) & 0xff) * intensity;
-          start += 3;
-          // TODO: map green and blue to UV
-        }
+        color_argb_t fg_color, bg_color, new_color;
+        bg_color.x = *start;
+        fg_color.x = opacity << 24 | ((textdata->is_stroke) ? textdata->stroke_color : textdata->color);
+        new_color = blend_colors_argb(bg_color, fg_color, BLEND_MODE_NORMAL);
+
+        *start = new_color.x;
+        //printf("0x%08x + 0x%08x = 0x%08x\n", prev_color.x, curr_color.x, new_color.x);
+
+        ++start;
       }
     }
     total_length = spans[i].x + spans[i].len;
@@ -956,6 +988,7 @@ static int draw_glyphs(TextData *textdata) {
   if (textdata->is_bitmap_ready) {
     // queue next textdata
     tmp_textdata->is_bitmap_ready = 1;
+    tmp_textdata->has_changed = 1;
     textdata->next_textdata = tmp_textdata;
   } else {
     // use existing textdata
@@ -967,6 +1000,7 @@ static int draw_glyphs(TextData *textdata) {
     textdata->width = tmp_textdata->width;
     textdata->height = tmp_textdata->height;
     textdata->is_bitmap_ready = 1;
+    textdata->has_changed = 1;
     free(tmp_textdata);
   }
 
@@ -1004,6 +1038,7 @@ int text_clear(int text_id) {
   }
   TextData *textdata = textdata_list[text_id-1];
   textdata->is_bitmap_ready = 0;
+  textdata->has_changed = 1;
   return 0;
 }
 
@@ -1044,9 +1079,15 @@ int text_get_position(int text_id, int canvas_width, int canvas_height, int *x, 
 
 /**
  * Draw all text objects to the canvas.
+ *
+ * returns: nonzero if the canvas content has been changed
  */
-void text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height) {
+int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_canvas_argb) {
   int i;
+  int has_anything_changed = 0;
+  int canvas_bytes_per_pixel = (is_canvas_argb) ? BYTES_PER_PIXEL : 1; // note: in YUV we're poinig to Y planar pixel
+  //clock_t start_time = clock();
+
   for (i = 0; i < max_text_id; i++) {
     TextData *textdata = textdata_list[i];
     if (textdata != NULL) {
@@ -1056,7 +1097,10 @@ void text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height) {
         TextData *next_textdata = textdata->next_textdata;
         memcpy(textdata, next_textdata, sizeof(TextData));
         free(next_textdata);
+        has_anything_changed = 1; // we're replacing old textdata with new one
       }
+      has_anything_changed |= textdata->has_changed;
+      textdata->has_changed = 0;
       if (textdata->is_bitmap_ready) {
         int pen_x, pen_y;
         text_get_position(textdata->id, canvas_width, canvas_height, &pen_x, &pen_y);
@@ -1076,31 +1120,48 @@ void text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height) {
               break;
             }
             int offset = (row * textdata->width + col) * BYTES_PER_PIXEL;
-            uint8_t opacity = textdata->bitmap[offset];
-            uint8_t red = textdata->bitmap[offset + 1];
-            // TODO: map colors to UV
-//            uint8_t green = textdata->bitmap[offset + 2];
-//            uint8_t blue = textdata->bitmap[offset + 3];
-            if (opacity == 255) {
-              if (textdata->blend_mode == BLEND_MODE_NORMAL) {
-                canvas[(pen_y + row) * canvas_width + (pen_x + col)] = red;
-              } else {
-                // TODO: Implement other blending modes
-                fprintf(stderr, "blending mode not implemented: %d\n",
-                    textdata->blend_mode);
+            color_argb_t color;
+            color.x = *((uint32_t*) (textdata->bitmap + offset));
+            uint8_t* canvas_pixel = canvas + ((pen_y + row) * canvas_width + (pen_x + col)) * canvas_bytes_per_pixel;
+
+            if (!is_canvas_argb) {
+              uint8_t opacity = color.c.a;
+              uint8_t y = ( (  66 * color.c.r + 129 * color.c.g +  25 * color.c.b + 128) >> 8) + 16;
+#if 0
+              uint8_t u = ( ( -38 * color.c.r -  74 * color.c.g + 112 * color.c.b + 128) >> 8) + 128;
+              uint8_t v = ( ( 112 * color.c.r -  94 * color.c.g -  18 * color.c.b + 128) >> 8) + 128;
+              (void)u; (void)v;
+#endif
+              if (opacity == 255) {
+                if (textdata->blend_mode == BLEND_MODE_NORMAL) {
+                  *canvas_pixel = y;
+                  // TODO: update U and V
+                } else {
+                  // TODO: Implement other blending modes
+                  fprintf(stderr, "blending mode not implemented: %d\n",
+                      textdata->blend_mode);
+                }
+              } else if (opacity > 0) {
+                // Blend colors
+                uint8_t orig_color_y = *canvas_pixel;
+                float intensity = opacity / 255.0f;
+                if (textdata->blend_mode == BLEND_MODE_NORMAL) {
+                  *canvas_pixel = orig_color_y * (1 - intensity) + y * intensity;
+                } else {
+                  // TODO: Implement other blending modes
+                  fprintf(stderr, "blending mode not implemented: %d\n",
+                      textdata->blend_mode);
+                }
               }
-            } else if (opacity > 0) {
-              // Blend colors
-              uint8_t orig_color = canvas[(pen_y + row) * canvas_width + (pen_x + col)];
-              float intensity = opacity / 255.0f;
-              if (textdata->blend_mode == BLEND_MODE_NORMAL) {
-                canvas[(pen_y + row) * canvas_width + (pen_x + col)] =
-                  orig_color * (1 - intensity) + red * intensity;
-              } else {
-                // TODO: Implement other blending modes
-                fprintf(stderr, "blending mode not implemented: %d\n",
-                    textdata->blend_mode);
-              }
+            } else { // is_canvas_argb == 1
+#ifdef USE_ARGB_PIXEL_BLENDING
+              color_argb_t bg_color, new_color;
+              bg_color.x = *((uint32_t*) canvas_pixel);
+              new_color = blend_colors_argb(bg_color, color, textdata->blend_mode);
+              *((uint32_t*) canvas_pixel) = new_color.x;
+#else
+              *((uint32_t*) canvas_pixel) = color.x;
+#endif
             }
           }
         }
@@ -1110,6 +1171,8 @@ void text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height) {
       }
     }
   }
+  //log_debug("text_draw_all(is_canvas_argb=%d) took %d ms\n", is_canvas_argb, (clock() - start_time) * 1000 / CLOCKS_PER_SEC);
+  return has_anything_changed;
 }
 
 /**

--- a/text.h
+++ b/text.h
@@ -71,6 +71,11 @@ int text_set_stroke_width(int text_id, float stroke_width);
 int text_set_color(int text_id, int color);
 
 /**
+ * Sets text visibility
+ */
+int text_set_visibility(int text_id, int in_preview, int in_video);
+
+/**
  * Sets multiplying factor for line spacing.
  * If this is set to 1, default line spacing is used.
  */
@@ -137,11 +142,11 @@ int redraw_text(int text_id);
 
 /**
  * Draw all text objects to the canvas.
- * we support writing on two types of canvas: ARGB8888 and YUV420PackedPlanar
+ * we support writing on two types of canvas: ARGB8888 (is_video = 0) and YUV420PackedPlanar (is_video = 1)
  *
  * returns: nonzero if the canvas content has been changed
  */
-int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_canvas_argb);
+int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_video);
 
 /**
  * Clear the text. Once this is called, the bitmap will not be drawn

--- a/text.h
+++ b/text.h
@@ -137,8 +137,11 @@ int redraw_text(int text_id);
 
 /**
  * Draw all text objects to the canvas.
+ * we support writing on two types of canvas: ARGB8888 and YUV420PackedPlanar
+ *
+ * returns: nonzero if the canvas content has been changed
  */
-void text_draw_all(uint8_t *canvas, int canvas_width, int video_height);
+int text_draw_all(uint8_t *canvas, int canvas_width, int canvas_height, int is_canvas_argb);
 
 /**
  * Clear the text. Once this is called, the bitmap will not be drawn


### PR DESCRIPTION
Render all texts on dedicated dispmanx overlay above the video rendering component. The texts are rendered using their RGB colors (not yet supported in video stream).

Additionally there is `in_preview|in_video` in subtitles hook to decide whether we want the subtitle to be present in the encoded video (so also in the live stream) and/or in the preview (on the Pi)