### PR TITLE
Feature/hls options

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,8 @@ Options:
   --audiopreviewdev <dev>  Audio preview output device (default: plughw:0,0)
  [HTTP Live Streaming (HLS)]
   -o, --hlsdir <dir>  Generate HTTP Live Streaming files in <dir>
+  --hlsnumberofsegments <num>  Set the number of segments in the m3u8 playlist (default: 3)
+  --hlskeyframespersegment <num>  Set the number of keyframes per video segment (default: 1)
   --hlsenc            Enable HLS encryption
   --hlsenckeyuri <uri>  Set HLS encryption key URI (default: stream.key)
   --hlsenckey <hex>   Set HLS encryption key in hex string

--- a/httplivestreaming.c
+++ b/httplivestreaming.c
@@ -161,6 +161,7 @@ void encrypt_most_recent_file(HTTPLiveStreaming *hls) {
 int calc_target_duration(HTTPLiveStreaming *hls) {
   float num = 0;
   float den = 0;
+  int i;
 
   // segments
   int from_seq = hls->most_recent_number - hls->num_recent_files + 1;
@@ -177,7 +178,7 @@ int calc_target_duration(HTTPLiveStreaming *hls) {
     den += 1.0f;
   }
 
-  if(den == 0f) {
+  if(den == 0.0f) {
     //No segments found. Return 0 as answer
     return 0;
   } else {

--- a/httplivestreaming.h
+++ b/httplivestreaming.h
@@ -14,7 +14,6 @@ typedef struct HTTPLiveStreaming {
   int num_recent_files;
   int num_retained_old_files;
   int most_recent_number;
-  int target_duration;
   char *dir;
   int is_started;
   int use_encryption;

--- a/stream.c
+++ b/stream.c
@@ -6031,9 +6031,9 @@ int main(int argc, char **argv) {
     //
     // So, num_recent_files should be 3 at the minimum.
 #if AUDIO_ONLY
-    hls = hls_create_audio_only(2, &codec_settings); // 2 == num_recent_files
+    hls = hls_create_audio_only(hls_number_of_segments-1, &codec_settings); // 2 == num_recent_files
 #else
-    hls = hls_create(2, &codec_settings); // 2 == num_recent_files
+    hls = hls_create(hls_number_of_segments-1, &codec_settings); // 2 == num_recent_files
 #endif
 
     if (is_hlsout_enabled) {

--- a/stream.c
+++ b/stream.c
@@ -19,7 +19,6 @@ extern "C" {
 #include <fcntl.h>
 #include <errno.h>
 #include <math.h>
-#include <limits.h>
 #include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -5528,10 +5527,6 @@ int main(int argc, char **argv) {
             log_fatal("error: invalid hlskeyframespersegment: %ld (must be > 0)\n", value);
             return EXIT_FAILURE;
           }
-          if (value > INT_MAX) {
-            log_fatal("error: invalid hlskeyframespersegment: %ld (must be < %d)\n", value, INT_MAX);
-            return EXIT_FAILURE;
-          }
           hls_keyframes_per_segment = (int) value;
         } else if (strcmp(long_options[option_index].name, "hlsnumberofsegments") == 0) {
           char *end;
@@ -5543,10 +5538,6 @@ int main(int argc, char **argv) {
           }
           if (value <= 0) {
             log_fatal("error: invalid hlsnumberofsegments: %ld (must be > 0)\n", value);
-            return EXIT_FAILURE;
-          }
-          if (value > INT_MAX) {
-            log_fatal("error: invalid hlsnumberofsegments: %ld (must be < %d)\n", value, INT_MAX);
             return EXIT_FAILURE;
           }
           hls_number_of_segments = (int) value;

--- a/stream.c
+++ b/stream.c
@@ -446,7 +446,7 @@ void stop_record();
 static void set_gop_size(int gop_size);
 #endif
 
-static unsigned long long video_keyframe_count = 0;
+static int video_send_keyframe_count = 0;
 static long long video_frame_count = 0;
 static long long audio_frame_count = 0;
 static int64_t video_start_time;
@@ -2214,10 +2214,13 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
       split = 1;
     }
 
+    // Update counter 
+    video_send_keyframe_count++;
+
     log_error("\n--------------\n");
     log_error("Split: %d\n", split);
     log_error("video_frame_count: %lld\n", video_frame_count);
-    log_error("video_keyframe_count: %llu\n", video_keyframe_count);
+    log_error("video_keyframe_count: %d\n", video_send_keyframe_count);
     log_error("--------------\n");
 
     ret = hls_write_packet(hls, &pkt, split);

--- a/stream.c
+++ b/stream.c
@@ -4672,8 +4672,8 @@ static void print_usage() {
   log_info("  --audiopreviewdev <dev>  Audio preview output device (default: %s)\n", audio_preview_dev_default);
   log_info(" [HTTP Live Streaming (HLS)]\n");
   log_info("  -o, --hlsdir <dir>  Generate HTTP Live Streaming files in <dir>\n");
-  log_info("  --hlsnumberofsegments <num>  Set the number of segments in the m3u8 playlist (default: %s)\n", hls_number_of_segments);
-  log_info("  --hlskeyframespersegment <num>  Set the number of keyframes per video segment (default: %s)\n", hls_keyframes_per_segment_default);
+  log_info("  --hlsnumberofsegments <num>  Set the number of segments in the m3u8 playlist (default: %d)\n", hls_number_of_segments);
+  log_info("  --hlskeyframespersegment <num>  Set the number of keyframes per video segment (default: %d)\n", hls_keyframes_per_segment_default);
   log_info("  --hlsenc            Enable HLS encryption\n");
   log_info("  --hlsenckeyuri <uri>  Set HLS encryption key URI (default: %s)\n", hls_encryption_key_uri_default);
   log_info("  --hlsenckey <hex>   Set HLS encryption key in hex string\n");

--- a/stream.c
+++ b/stream.c
@@ -2208,14 +2208,14 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
     pthread_mutex_lock(&mutex_writing);
     int split;
 
-    // Update counter 
-    video_send_keyframe_count++;
-
-    if (video_send_keyframe_count % hls_keyframes_per_segment == 0) {
+    if (video_send_keyframe_count % hls_keyframes_per_segment == 0 && video_frame_count != 0) {
       split = 1;
     } else {
       split = 0;
     }
+
+    // Update counter 
+    video_send_keyframe_count++;
 
     log_error("\n--------------\n");
     log_error("Split: %d\n", split);

--- a/stream.c
+++ b/stream.c
@@ -2208,17 +2208,18 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
     pthread_mutex_lock(&mutex_writing);
     int split;
 
-    log_error("\n--------------\n");
-    log_error("Split: %d\n", split);
-    log_error("video_frame_count: %ll\n", video_frame_count);
-    log_error("video_keyframe_count: %ll\n", video_keyframe_count);
-    log_error("--------------\n");
-
     if (video_frame_count == 1) {
       split = 0;
     } else {
       split = 1;
     }
+
+    log_error("\n--------------\n");
+    log_error("Split: %d\n", split);
+    log_error("video_frame_count: %lld\n", video_frame_count);
+    log_error("video_keyframe_count: %llu\n", video_keyframe_count);
+    log_error("--------------\n");
+
     ret = hls_write_packet(hls, &pkt, split);
     pthread_mutex_unlock(&mutex_writing);
     if (ret < 0) {

--- a/stream.c
+++ b/stream.c
@@ -2214,7 +2214,7 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
       split = 0;
     }
 
-    video_send_keyframe_count = video_send_keyframe_count % hls_keyframes_per_segment_default;    
+    video_send_keyframe_count = video_send_keyframe_count % hls_keyframes_per_segment;    
 
     // Update counter 
     video_send_keyframe_count++;

--- a/stream.c
+++ b/stream.c
@@ -2208,11 +2208,13 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
     pthread_mutex_lock(&mutex_writing);
     int split;
 
-    if (video_send_keyframe_count % hls_keyframes_per_segment == 0 && video_frame_count != 0) {
+    if (video_send_keyframe_count % hls_keyframes_per_segment == 0 && video_frame_count != 1) {
       split = 1;
     } else {
       split = 0;
     }
+
+    video_send_keyframe_count = video_send_keyframe_count % hls_keyframes_per_segment_default;    
 
     // Update counter 
     video_send_keyframe_count++;

--- a/stream.c
+++ b/stream.c
@@ -6031,9 +6031,9 @@ int main(int argc, char **argv) {
     //
     // So, num_recent_files should be 3 at the minimum.
 #if AUDIO_ONLY
-    hls = hls_create_audio_only(hls_number_of_segments-1, &codec_settings); // 2 == num_recent_files
+    hls = hls_create_audio_only(hls_number_of_segments, &codec_settings); // 2 == num_recent_files
 #else
-    hls = hls_create(hls_number_of_segments-1, &codec_settings); // 2 == num_recent_files
+    hls = hls_create(hls_number_of_segments, &codec_settings); // 2 == num_recent_files
 #endif
 
     if (is_hlsout_enabled) {

--- a/stream.c
+++ b/stream.c
@@ -6038,7 +6038,6 @@ int main(int argc, char **argv) {
 
     if (is_hlsout_enabled) {
       hls->dir = hls_output_dir;
-      hls->target_duration = 1;
       hls->num_retained_old_files = 10;
       if (is_hls_encryption_enabled) {
         hls->use_encryption = 1;

--- a/stream.c
+++ b/stream.c
@@ -446,6 +446,7 @@ void stop_record();
 static void set_gop_size(int gop_size);
 #endif
 
+static unsigned long long video_keyframe_count = 0;
 static long long video_frame_count = 0;
 static long long audio_frame_count = 0;
 static int64_t video_start_time;
@@ -2206,6 +2207,13 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
   if (is_hlsout_enabled) {
     pthread_mutex_lock(&mutex_writing);
     int split;
+
+    log_error("\n--------------\n");
+    log_error("Split: %d\n", split);
+    log_error("video_frame_count: %ll\n", video_frame_count);
+    log_error("video_keyframe_count: %ll\n", video_keyframe_count);
+    log_error("--------------\n");
+
     if (video_frame_count == 1) {
       split = 0;
     } else {

--- a/stream.c
+++ b/stream.c
@@ -2219,12 +2219,6 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
     // Update counter 
     video_send_keyframe_count++;
 
-    log_error("\n--------------\n");
-    log_error("Split: %d\n", split);
-    log_error("video_frame_count: %lld\n", video_frame_count);
-    log_error("video_keyframe_count: %d\n", video_send_keyframe_count);
-    log_error("--------------\n");
-
     ret = hls_write_packet(hls, &pkt, split);
     pthread_mutex_unlock(&mutex_writing);
     if (ret < 0) {

--- a/stream.c
+++ b/stream.c
@@ -2208,14 +2208,14 @@ static int send_keyframe(uint8_t *data, size_t data_len, int consume_time) {
     pthread_mutex_lock(&mutex_writing);
     int split;
 
-    if (video_frame_count == 1) {
-      split = 0;
-    } else {
-      split = 1;
-    }
-
     // Update counter 
     video_send_keyframe_count++;
+
+    if (video_send_keyframe_count % hls_keyframes_per_segment == 0) {
+      split = 1;
+    } else {
+      split = 0;
+    }
 
     log_error("\n--------------\n");
     log_error("Split: %d\n", split);


### PR DESCRIPTION
First thank you for your great program. As far as I know picam is the only streaming solution where audio and video are in sync.

In  this branch I added two command line arguments:
```
--hlsnumberofsegments <num>  Set the number of segments in the m3u8 playlist (default: 3)
--hlskeyframespersegment <num>  Set the number of keyframes per video segment (default: 1)
```
With these options one can enable DVR functionality with the HLS streaming protocol. That is, with a video player like clappr one can playback the livestream with a delay. Without these options one cannot delay the stream for more than two seconds.

Also, I change the behaviour for the target duration. Namely, I calculate the target duration based on the average duration of the last _x_ segments. Using this method we still generate valid m3u8 files with the new command line options.

I tested the code on a raspberry pi 3b+. There it works.