### PR TITLE
more build instruction

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -37,6 +37,11 @@ Download ffmpeg source and configure it:
 ```sh
 $ git clone https://git.ffmpeg.org/ffmpeg.git
 $ cd ffmpeg
+$ git checkout n4.3 -b n4.3
+# NOTE: for extra hw acceleration, include these flags in your ./configure below:
+#         --enable-mmal
+#         --enable-omx
+#         --enable-omx-rpi
 $ ./configure --enable-libfdk-aac
 (takes about one minute)
 ```


### PR DESCRIPTION
picam doesn't build with the bleeding edge master branch of ffmpeg, but it does build with the latest release 4.3.  This updates BUILDING.md to help the user know which version of ffmpeg to build an also includes notes about extra hw acceleration flags for the raspberr pi.

this is fix 2 of 2 for issue https://github.com/iizukanao/picam/issues/144