### PR TITLE
Add bullseye build selection step into readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,14 @@ chmod +x make_dirs.sh
 # Optionally, increase microphone volume with alsamixer
 alsamixer
 
+# For bullseye version - separate build is used
+is_bullseye=""
+if [ "$(cat /etc/*-release | grep VERSION_CODENAME | awk -F '=' '{ print $2 }')" == "bullseye" ]; then
+  is_bullseye="bullseye-"
+fi
+
 # Install picam binary
-wget https://github.com/iizukanao/picam/releases/download/v2.0.12/picam-2.0.12-`uname -m`.tar.xz
+wget https://github.com/iizukanao/picam/releases/download/v2.0.12/picam-2.0.12-$is_bullseye`uname -m`.tar.xz
 tar xvf picam-2.0.12-*.tar.xz
 cp picam-2.0.12-*/picam ~/picam/
 


### PR DESCRIPTION
Tried to use **picam** on RPi3B+ (Raspberry Pi Imager seems to propose Debian Bullseye image),

Followed instructions on **README.md** and after trying to launch picam run into **libcamera.so** missing issue:

```
./picam --alsadev hw:1,0

./picam: error while loading shared libraries: libcamera.so.0.1: cannot open shared object file: No such file or directory
```

Started to look into this repo issues and noticed that package upgrade could help: 
```
sudo apt update && sudo apt upgrade 
```

but no luck.

Wanted to build from source myself - but still decided to look at releases again.

And noticed that bullseye has a different binary.

So I added a small snippet to install instructions in Readme that adds `bullseye-` if commands are executed on `bullseye`


Works on bullseye, I assume it should work on bookworm too. 